### PR TITLE
add option in frodoProtocols to include a pulse to measure input resistance at the beginning of the trial

### DIFF
--- a/frodoProtocols.m
+++ b/frodoProtocols.m
@@ -38,6 +38,17 @@ while 1
         break;
     end % exit whole set of code
 
+    % option to add a pulse at the beginning of the trial to measure input resistance
+    pulsePrompt = ['Do you want to include a pulse at the beginning of the trial? '];
+    pulseAns = input( pulsePrompt, 's');
+
+    if pulseAns == 'y'
+        PULSE_AMPLITUDE = -2; %pA
+        PULSE_DURATION = 0.05; %sec
+        [ pulseCommandArray ] =  currentStepPulse( PULSE_AMPLITUDE, PULSE_DURATION );
+        stimulus.command.output = [ pulseCommandArray stimulus.command.output ];
+    end
+
     % plot command, and Trigger signal that are in stimulus
     plotCommandSignals( stimulus );
 
@@ -403,6 +414,23 @@ finalArray = [Array_BaselineOne stepArray Array_BaselineTwo stepArray Array_post
 fprintf('Running the 15-20 minute multiple current injection protocol');
 commandArray = finalArray * rigSettings.command.currentClampExternalCommandGain; % send full command out, in Voltage for the daq to send
 out.command = buildOutputSignal('command', commandArray);
+end
+
+
+%%
+function [pulseCommandArray] = currentStepPulse( pulseAmp, pulseDur )
+ephysSettings;
+
+BREAK_DURATION = 0.05; %sec
+
+preStepCommand = zeros(1, BREAK_DURATION * rigSettings.sampRate );
+
+stepCommand = pulseAmp * ones( 1, pulseDur * rigSettings.sampRate );
+
+pulseCommand = [preStepCommand stepCommand preStepCommand];
+
+pulseCommandArray = pulseCommand * rigSettings.command.currentClampExternalCommandGain; % send full command out, in Voltage for the daq to send
+
 end
 
 

--- a/frodoProtocols.m
+++ b/frodoProtocols.m
@@ -22,7 +22,7 @@ while 1
         try
             % evaluate stimulus contruction code and obtain the current command wave form to be used.
             stimulus = eval(choosenStimulus);
-            stimulus.name = choosenStimulus; % Also store information about the stimlulus name and waveform
+            stimulus.name = choosenStimulus; % Also store information about the stimulus name and waveform
 
             GETSTIMULUSNAME = false; % If eval ran without breaking, exit this loop and continue on with the rest of the code
         catch
@@ -133,7 +133,10 @@ else
     INTERSTIMINTERVAL = 1; % seconds
 end
 
-stepAmplitudeChange = (upperCurrentBound - lowerCurrentBound)/(NUMBER_OF_STEPS-1); %pA
+%stepAmplitudeChange = (upperCurrentBound -
+%lowerCurrentBound)/(NUMBER_OF_STEPS-1); %pA I'm not sure why there's a -1
+%to the numSteps........
+stepAmplitudeChange = (upperCurrentBound - lowerCurrentBound)/(NUMBER_OF_STEPS); %pA
 
 injectionCommand = [];
 for i = 1: NUMBER_OF_STEPS

--- a/frodoProtocols.m
+++ b/frodoProtocols.m
@@ -423,11 +423,11 @@ ephysSettings;
 
 BREAK_DURATION = 0.05; %sec
 
-preStepCommand = zeros(1, BREAK_DURATION * rigSettings.sampRate );
+breakStepCommand = zeros(1, BREAK_DURATION * rigSettings.sampRate );
 
 stepCommand = pulseAmp * ones( 1, pulseDur * rigSettings.sampRate );
 
-pulseCommand = [preStepCommand stepCommand preStepCommand];
+pulseCommand = [breakStepCommand stepCommand breakStepCommand];
 
 pulseCommandArray = pulseCommand * rigSettings.command.currentClampExternalCommandGain; % send full command out, in Voltage for the daq to send
 


### PR DESCRIPTION
add option to have a pulse at the beginning of the trial in frodoProtocols
- after choosing stimulus, ask use whether they want to include a pulse at the beginning of the trial
- if yes, run new function currentStepPulse with hard-coded amplitude + duration values and append to stimulus command
- if no, runs stimulus without pulse